### PR TITLE
Move simple API to /simple and add shutdown endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pip-timemachine 2023-10-18T12:00:00
 
 And then point pip (or any other installer) to use this server as an index:
 ```bash
-pip install requests --index http://127.0.0.1:8040
+pip install requests --index http://127.0.0.1:8040/simple
 ```
 
 ### CLI Options


### PR DESCRIPTION
uvicorn doesn't seem to gracefully shutdown when sigtermed, so adding an endpoint to allow users to shutdown.

This requires moving the simple API to the `/simple` endpoint so it doesn't conflict this, or future endpoints.